### PR TITLE
도메인별 논리적 삭제코드 작성 및 연관관계 처리, 재고등록 조건추가

### DIFF
--- a/src/main/java/server/bookmanagement/domain/book/repository/BookRepository.java
+++ b/src/main/java/server/bookmanagement/domain/book/repository/BookRepository.java
@@ -7,5 +7,6 @@ import org.springframework.stereotype.Repository;
 import server.bookmanagement.domain.book.entity.Book;
 @Repository
 public interface BookRepository extends JpaRepository<Book,Long> {
+    // 리펙토리시 QueryDSL 로 변경
     Page<Book> findByIsDeletedFalse(Pageable pageable);
 }

--- a/src/main/java/server/bookmanagement/domain/book/service/BookService.java
+++ b/src/main/java/server/bookmanagement/domain/book/service/BookService.java
@@ -2,14 +2,19 @@ package server.bookmanagement.domain.book.service;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import server.bookmanagement.domain.book.repository.BookRepository;
 import server.bookmanagement.domain.book.entity.Book;
+import server.bookmanagement.domain.library.inventory.entity.LibraryInventory;
 import server.bookmanagement.global.error.exception.BusinessLogicException;
 import server.bookmanagement.global.error.exception.ExceptionCode;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -38,11 +43,33 @@ public class BookService {
         return bookRepository.save(book);
     }
 
-    public Book findById(long id){
-        Optional<Book> optionalBook = bookRepository.findById(id);
-        Book book = optionalBook.orElseThrow(() -> new BusinessLogicException(ExceptionCode.BOOK_NOT_FOUND));
-        if(book.isDeleted()) {
-            throw new BusinessLogicException(ExceptionCode.BOOK_IS_DELETED);
-        } else return book;
+    public Book findById(long id) {
+        Book book = findBookById(id);
+        validateBookNotDeleted(book);
+        filterDeletedLibraryInventories(book);
+
+        return book;
     }
+
+    private Book findBookById(long id) {
+        return bookRepository.findById(id)
+                .orElseThrow(() -> new BusinessLogicException(ExceptionCode.BOOK_NOT_FOUND));
+    }
+
+    private void validateBookNotDeleted(Book book) {
+        if (book.isDeleted()) {
+            throw new BusinessLogicException(ExceptionCode.BOOK_IS_DELETED);
+        }
+    }
+
+    private void filterDeletedLibraryInventories(Book book) {
+        List<LibraryInventory> filteredLibraryInventories = book.getLibraryInventories()
+                .stream()
+                .filter(libraryInventory -> !libraryInventory.isDeleted())
+                .collect(Collectors.toList());
+
+        book.setLibraryInventories(filteredLibraryInventories);
+    }
+
+
 }

--- a/src/main/java/server/bookmanagement/domain/book/service/BookService.java
+++ b/src/main/java/server/bookmanagement/domain/book/service/BookService.java
@@ -2,7 +2,6 @@ package server.bookmanagement.domain.book.service;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import server.bookmanagement.domain.book.repository.BookRepository;
@@ -11,7 +10,6 @@ import server.bookmanagement.domain.library.inventory.entity.LibraryInventory;
 import server.bookmanagement.global.error.exception.BusinessLogicException;
 import server.bookmanagement.global.error.exception.ExceptionCode;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;

--- a/src/main/java/server/bookmanagement/domain/library/inventory/controller/LibraryInventoryController.java
+++ b/src/main/java/server/bookmanagement/domain/library/inventory/controller/LibraryInventoryController.java
@@ -12,17 +12,21 @@ import server.bookmanagement.domain.library.inventory.mapper.LibraryInventoryMap
 import server.bookmanagement.domain.library.inventory.service.LibraryInventoryService;
 import server.bookmanagement.domain.library.library.entity.Library;
 import server.bookmanagement.domain.library.library.service.LibraryService;
+import server.bookmanagement.domain.loan.entity.Loan;
+import server.bookmanagement.domain.loan.service.LoanService;
 import server.bookmanagement.global.dto.SingleResponseDto;
 
 import javax.transaction.Transactional;
+import java.util.List;
 
 @RestController
-@RequestMapping("/library/inventory")
+@RequestMapping("/libraries/inventories")
 @RequiredArgsConstructor
 public class LibraryInventoryController {
     private final LibraryInventoryService libraryInventoryService;
     private final LibraryService libraryService;
     private final BookService bookService;
+    private final LoanService loanService;
     private final LibraryInventoryMapper libraryInventoryMapper;
     @PostMapping
     public ResponseEntity<?> bookRegistrationInLibrary(@RequestBody LibraryInventoryDto.Post post) {
@@ -53,6 +57,9 @@ public class LibraryInventoryController {
     @DeleteMapping("/{library-inventory-id}")
     public ResponseEntity<?> bookDeleteInLibrary(@PathVariable("library-inventory-id") long libraryInventoryId) {
         LibraryInventory libraryInventory = libraryInventoryService.findById(libraryInventoryId);
+//        List<Loan> byLibraryInventoryId = loanService.findByLibraryInventoryId(libraryInventoryId);
+//        loanService.setReturn(byLibraryInventoryId);
+
         LibraryInventory deletedLibraryInventory = libraryInventoryService.bookDeleteInLibrary(libraryInventory);
 
         LibraryInventoryDto.Response response = libraryInventoryMapper.LibraryInventoryToResponse(deletedLibraryInventory);

--- a/src/main/java/server/bookmanagement/domain/library/inventory/controller/LibraryInventoryController.java
+++ b/src/main/java/server/bookmanagement/domain/library/inventory/controller/LibraryInventoryController.java
@@ -30,9 +30,9 @@ public class LibraryInventoryController {
         Library library = libraryService.findById(post.getLibraryId());
         Book book = bookService.findById(post.getBookId());
         LibraryInventory libraryInventory = libraryInventoryMapper.LibraryInventoryPostToLibraryInventory(post);
-
         libraryInventory.setLibrary(library);
         libraryInventory.setBook(book);
+
         LibraryInventory registration = libraryInventoryService.bookRegistrationInLibrary(libraryInventory);
 
         LibraryInventoryDto.Response response = libraryInventoryMapper.LibraryInventoryToResponse(registration);

--- a/src/main/java/server/bookmanagement/domain/library/inventory/controller/LibraryInventoryController.java
+++ b/src/main/java/server/bookmanagement/domain/library/inventory/controller/LibraryInventoryController.java
@@ -3,10 +3,7 @@ package server.bookmanagement.domain.library.inventory.controller;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 import server.bookmanagement.domain.book.entity.Book;
 import server.bookmanagement.domain.book.service.BookService;
 import server.bookmanagement.domain.library.inventory.dto.LibraryInventoryDto;
@@ -16,6 +13,8 @@ import server.bookmanagement.domain.library.inventory.service.LibraryInventorySe
 import server.bookmanagement.domain.library.library.entity.Library;
 import server.bookmanagement.domain.library.library.service.LibraryService;
 import server.bookmanagement.global.dto.SingleResponseDto;
+
+import javax.transaction.Transactional;
 
 @RestController
 @RequestMapping("/library/inventory")
@@ -27,15 +26,36 @@ public class LibraryInventoryController {
     private final LibraryInventoryMapper libraryInventoryMapper;
     @PostMapping
     public ResponseEntity<?> bookRegistrationInLibrary(@RequestBody LibraryInventoryDto.Post post) {
+        //Todo : 같은 도서관에 이미 등록된 책이면 예외처리 해야함.
         Library library = libraryService.findById(post.getLibraryId());
         Book book = bookService.findById(post.getBookId());
         LibraryInventory libraryInventory = libraryInventoryMapper.LibraryInventoryPostToLibraryInventory(post);
 
         libraryInventory.setLibrary(library);
         libraryInventory.setBook(book);
-        LibraryInventory registration = libraryInventoryService.registrationInLibrary(libraryInventory);
+        LibraryInventory registration = libraryInventoryService.bookRegistrationInLibrary(libraryInventory);
 
         LibraryInventoryDto.Response response = libraryInventoryMapper.LibraryInventoryToResponse(registration);
+        return new ResponseEntity<>(new SingleResponseDto<>(response), HttpStatus.OK);
+    }
+
+    @Transactional
+    @PatchMapping("/{library-inventory-id}")
+    public ResponseEntity<?> patchLibraryInventory(@PathVariable("library-inventory-id") long libraryInventoryId,
+                                                   @RequestBody LibraryInventoryDto.Patch patch) {
+        LibraryInventory libraryInventory = libraryInventoryMapper.LibraryInventoryPatchToLibraryInventory(patch);
+        libraryInventory.setId(libraryInventoryId);
+        LibraryInventory updatedLibraryInventory = libraryInventoryService.updateLibraryInventory(libraryInventory);
+        LibraryInventoryDto.Response response = libraryInventoryMapper.LibraryInventoryToResponse(updatedLibraryInventory);
+        return new ResponseEntity<>(new SingleResponseDto<>(response),HttpStatus.OK);
+    }
+
+    @DeleteMapping("/{library-inventory-id}")
+    public ResponseEntity<?> bookDeleteInLibrary(@PathVariable("library-inventory-id") long libraryInventoryId) {
+        LibraryInventory libraryInventory = libraryInventoryService.findById(libraryInventoryId);
+        LibraryInventory deletedLibraryInventory = libraryInventoryService.bookDeleteInLibrary(libraryInventory);
+
+        LibraryInventoryDto.Response response = libraryInventoryMapper.LibraryInventoryToResponse(deletedLibraryInventory);
         return new ResponseEntity<>(new SingleResponseDto<>(response), HttpStatus.OK);
     }
 }

--- a/src/main/java/server/bookmanagement/domain/library/inventory/dto/LibraryInventoryDto.java
+++ b/src/main/java/server/bookmanagement/domain/library/inventory/dto/LibraryInventoryDto.java
@@ -17,6 +17,11 @@ public class LibraryInventoryDto {
         private int totalQuantity;
     }
     @Getter
+    @NoArgsConstructor
+    public static class Patch{
+        private int totalQuantity;
+    }
+    @Getter
     @Setter
     @NoArgsConstructor
     public static class BookResponse {

--- a/src/main/java/server/bookmanagement/domain/library/inventory/entity/LibraryInventory.java
+++ b/src/main/java/server/bookmanagement/domain/library/inventory/entity/LibraryInventory.java
@@ -1,14 +1,17 @@
 package server.bookmanagement.domain.library.inventory.entity;
 
 import com.fasterxml.jackson.annotation.JsonBackReference;
+import com.fasterxml.jackson.annotation.JsonManagedReference;
 import lombok.Getter;
 import lombok.Setter;
 import org.hibernate.annotations.ColumnDefault;
 import server.bookmanagement.domain.book.entity.Book;
 import server.bookmanagement.domain.library.library.entity.Library;
+import server.bookmanagement.domain.loan.entity.Loan;
 import server.bookmanagement.util.BaseEntity;
 
 import javax.persistence.*;
+import java.util.List;
 
 @Entity
 @Setter
@@ -28,6 +31,10 @@ public class LibraryInventory extends BaseEntity {
     @JoinColumn(name = "library_id")
     @JsonBackReference
     private Library library;
+
+    @OneToMany(mappedBy = "libraryInventory", cascade = CascadeType.REMOVE)
+    @JsonManagedReference
+    private List<Loan> loans;
 
     public enum LoanStatus{
         대여가능, 모두대여중

--- a/src/main/java/server/bookmanagement/domain/library/inventory/entity/LibraryInventory.java
+++ b/src/main/java/server/bookmanagement/domain/library/inventory/entity/LibraryInventory.java
@@ -19,6 +19,7 @@ public class LibraryInventory extends BaseEntity {
     private int loanQuantity; // 1 , 2  ... 5
     @Enumerated(value = EnumType.STRING)
     private LoanStatus loanStatus = LoanStatus.대여가능; // 모두 대여중
+    private boolean isDeleted = false;
     @ManyToOne
     @JoinColumn(name = "book_id")
     @JsonBackReference

--- a/src/main/java/server/bookmanagement/domain/library/inventory/mapper/LibraryInventoryMapper.java
+++ b/src/main/java/server/bookmanagement/domain/library/inventory/mapper/LibraryInventoryMapper.java
@@ -10,7 +10,6 @@ import java.util.List;
 @Mapper(componentModel = "spring",unmappedTargetPolicy = ReportingPolicy.IGNORE)
 public interface LibraryInventoryMapper {
     LibraryInventory LibraryInventoryPostToLibraryInventory(LibraryInventoryDto.Post post);
-//    LibraryInventoryDto.LibraryResponse LibraryInventoryToLibraryResponse(LibraryInventory libraryInventory);
+    LibraryInventory LibraryInventoryPatchToLibraryInventory(LibraryInventoryDto.Patch patch);
     LibraryInventoryDto.Response LibraryInventoryToResponse(LibraryInventory libraryInventory);
-//    List<LibraryInventoryDto.LibraryResponse> LibraryInventoriesToLibraryResponses(List<LibraryInventory> libraryInventories);
 }

--- a/src/main/java/server/bookmanagement/domain/library/inventory/service/LibraryInventoryService.java
+++ b/src/main/java/server/bookmanagement/domain/library/inventory/service/LibraryInventoryService.java
@@ -15,7 +15,26 @@ public class LibraryInventoryService {
     private final LibraryInventoryRepository libraryInventoryRepository;
 
 
-    public LibraryInventory registrationInLibrary(LibraryInventory libraryInventory) {
+    public LibraryInventory bookRegistrationInLibrary(LibraryInventory libraryInventory) {
+        return libraryInventoryRepository.save(libraryInventory);
+    }
+
+    public LibraryInventory updateLibraryInventory(LibraryInventory libraryInventory) {
+        LibraryInventory findLibraryInventory = findById(libraryInventory.getId());
+        int loanQuantity = findLibraryInventory.getLoanQuantity();
+        int updateTotalQuantity = libraryInventory.getTotalQuantity();
+
+        //Todo: 만약에 대여중인 책이 있으면 대여중인 수량 이하로는 전체수량 변경 불가능하게 해야함
+        if( loanQuantity > updateTotalQuantity) {
+            throw new BusinessLogicException(ExceptionCode.QUANTITY_UPDATE_IMPOSSIBLE);
+        } else {
+            Optional.of(libraryInventory.getTotalQuantity()).ifPresent(findLibraryInventory::setTotalQuantity);
+            return libraryInventoryRepository.save(findLibraryInventory);
+        }
+    }
+
+    public LibraryInventory bookDeleteInLibrary(LibraryInventory libraryInventory) {
+        libraryInventory.setDeleted(true);
         return libraryInventoryRepository.save(libraryInventory);
     }
 
@@ -41,7 +60,10 @@ public class LibraryInventoryService {
 
     public LibraryInventory findById(long id) {
         Optional<LibraryInventory> optionalLibraryInventory = libraryInventoryRepository.findById(id);
-        return optionalLibraryInventory.orElseThrow(()->new BusinessLogicException(ExceptionCode.LIBRARY_INVENTORY_NOT_FOUND));
+        LibraryInventory libraryInventory = optionalLibraryInventory.orElseThrow(() -> new BusinessLogicException(ExceptionCode.LIBRARY_INVENTORY_NOT_FOUND));
+        if(libraryInventory.isDeleted()) {
+            throw new BusinessLogicException(ExceptionCode.LIBRARY_INVENTORY_NOT_FOUND);
+        } else return libraryInventory;
     }
 
     public void validLoanStatus(LibraryInventory libraryInventory){

--- a/src/main/java/server/bookmanagement/domain/library/inventory/service/LibraryInventoryService.java
+++ b/src/main/java/server/bookmanagement/domain/library/inventory/service/LibraryInventoryService.java
@@ -3,10 +3,13 @@ package server.bookmanagement.domain.library.inventory.service;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import server.bookmanagement.domain.library.inventory.repository.LibraryInventoryRepository;
+import server.bookmanagement.domain.loan.entity.Loan;
+import server.bookmanagement.domain.loan.service.LoanService;
 import server.bookmanagement.global.error.exception.BusinessLogicException;
 import server.bookmanagement.global.error.exception.ExceptionCode;
 import server.bookmanagement.domain.library.inventory.entity.LibraryInventory;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
@@ -14,6 +17,7 @@ import java.util.Optional;
 @RequiredArgsConstructor
 public class LibraryInventoryService {
     private final LibraryInventoryRepository libraryInventoryRepository;
+    private final LoanService loanService;
 
 
     public LibraryInventory bookRegistrationInLibrary(LibraryInventory libraryInventory) {
@@ -61,7 +65,7 @@ public class LibraryInventoryService {
     public LibraryInventory bookDeleteInLibrary(LibraryInventory libraryInventory) {
         libraryInventory.setDeleted(true);
         return libraryInventoryRepository.save(libraryInventory);
-        //Todo : 누가 책을 대여중인데 삭제시키려면
+        //Todo : 누가 책을 대여중인데 삭제시키려면 ? 반납가능 and
         // 삭제되게함. -> 그 member
     }
 

--- a/src/main/java/server/bookmanagement/domain/library/library/controller/LibraryController.java
+++ b/src/main/java/server/bookmanagement/domain/library/library/controller/LibraryController.java
@@ -1,7 +1,6 @@
 package server.bookmanagement.domain.library.library.controller;
 
 import lombok.RequiredArgsConstructor;
-import org.springframework.beans.factory.annotation.Required;
 import org.springframework.data.domain.Page;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;

--- a/src/main/java/server/bookmanagement/domain/library/library/controller/LibraryController.java
+++ b/src/main/java/server/bookmanagement/domain/library/library/controller/LibraryController.java
@@ -13,6 +13,7 @@ import server.bookmanagement.domain.library.library.dto.LibraryDto;
 import server.bookmanagement.domain.library.library.mapper.LibraryMapper;
 import server.bookmanagement.domain.library.library.service.LibraryService;
 
+import javax.transaction.Transactional;
 import java.util.List;
 
 @RestController
@@ -56,7 +57,7 @@ public class LibraryController {
         return new ResponseEntity<>(new MultiResponseDto<>(response,librariesPage), HttpStatus.OK);
 
     }
-
+    @Transactional
     @DeleteMapping("{library-id}")
     public ResponseEntity<?> deleteLibrary(@PathVariable("library-id") long libraryId) {
         Library library = libraryService.findById(libraryId);

--- a/src/main/java/server/bookmanagement/domain/library/library/service/LibraryService.java
+++ b/src/main/java/server/bookmanagement/domain/library/library/service/LibraryService.java
@@ -6,6 +6,7 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import server.bookmanagement.domain.library.inventory.entity.LibraryInventory;
 import server.bookmanagement.domain.library.library.entity.Library;
+import server.bookmanagement.domain.loan.service.LoanService;
 import server.bookmanagement.global.error.exception.BusinessLogicException;
 import server.bookmanagement.global.error.exception.ExceptionCode;
 import server.bookmanagement.domain.library.library.repository.LibraryRepository;
@@ -37,6 +38,7 @@ public class LibraryService {
         for(LibraryInventory libraryInventory : libraryInventories) {
             libraryInventory.setDeleted(true);
         }
+
         return libraryRepository.save(library);
     }
 

--- a/src/main/java/server/bookmanagement/domain/library/library/service/LibraryService.java
+++ b/src/main/java/server/bookmanagement/domain/library/library/service/LibraryService.java
@@ -4,11 +4,13 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
+import server.bookmanagement.domain.library.inventory.entity.LibraryInventory;
 import server.bookmanagement.domain.library.library.entity.Library;
 import server.bookmanagement.global.error.exception.BusinessLogicException;
 import server.bookmanagement.global.error.exception.ExceptionCode;
 import server.bookmanagement.domain.library.library.repository.LibraryRepository;
 
+import java.util.List;
 import java.util.Optional;
 
 @Service
@@ -18,7 +20,6 @@ public class LibraryService {
     public Library createLibrary(Library library) {
         return libraryRepository.save(library);
     }
-
 
     public Library pathchLibrary(Library library) {
         Library findLibrary = findById(library.getId());
@@ -32,6 +33,10 @@ public class LibraryService {
 
     public Library deleteLibrary(Library library) {
         library.setDeleted(true);
+        List<LibraryInventory> libraryInventories = library.getLibraryInventories();
+        for(LibraryInventory libraryInventory : libraryInventories) {
+            libraryInventory.setDeleted(true);
+        }
         return libraryRepository.save(library);
     }
 

--- a/src/main/java/server/bookmanagement/domain/loan/controller/LoanController.java
+++ b/src/main/java/server/bookmanagement/domain/loan/controller/LoanController.java
@@ -66,6 +66,7 @@ public class LoanController {
         // 조건0. 이미 반납 상태이면 반납 처리 되면 안됨
         // 조건1. 해당 회원이 빌린 책이 맞는지 확인 필요 -> 안맞을시 예외 오류 response ->
         // 조건2. 날짜 확인후 연체 여부확인 및 패널티 부여 (연체된 날짜만큼 대여 불가능) -> 정상작동 및 member 상태변경
+        // 책반납
         loanService.validReturn(loan);
         loanService.validMemberMatch(loan, post.getMemberId());
         loan.setReturnedAt(LocalDateTime.now());

--- a/src/main/java/server/bookmanagement/domain/loan/entity/Loan.java
+++ b/src/main/java/server/bookmanagement/domain/loan/entity/Loan.java
@@ -19,6 +19,7 @@ public class Loan {
     private LocalDateTime returnedAt;
     @Enumerated(value = EnumType.STRING)
     private LoanStats loanStats = LoanStats.대여중;
+    // 회원이 삭제될때, 책이 삭제될때, 도서관이 삭제될때, 도서관이 삭제될때
     @ManyToOne
     @JoinColumn(name = "member_id")
     @JsonBackReference

--- a/src/main/java/server/bookmanagement/domain/loan/repository/LoanRepository.java
+++ b/src/main/java/server/bookmanagement/domain/loan/repository/LoanRepository.java
@@ -4,6 +4,9 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 import server.bookmanagement.domain.loan.entity.Loan;
 
+import java.util.List;
+
 @Repository
 public interface LoanRepository extends JpaRepository<Loan,Long> {
+    List<Loan> findByLibraryInventoryId(long libraryInventoryId);
 }

--- a/src/main/java/server/bookmanagement/domain/loan/service/LoanService.java
+++ b/src/main/java/server/bookmanagement/domain/loan/service/LoanService.java
@@ -1,7 +1,6 @@
 package server.bookmanagement.domain.loan.service;
 
 import lombok.RequiredArgsConstructor;
-import net.bytebuddy.implementation.bytecode.Duplication;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import server.bookmanagement.domain.loan.entity.Loan;
@@ -33,6 +32,15 @@ public class LoanService {
         loan.setLoanStats(Loan.LoanStats.반납완료);
         return loanRepository.save(loan);
     }
+    public List<Loan> findByLibraryInventoryId(long libraryInventoryId) {
+        return loanRepository.findByLibraryInventoryId(libraryInventoryId);
+    }
+    public void setReturn(List<Loan> loans) {
+        for(Loan loan : loans) {
+            loan.setReturnedAt(LocalDateTime.now());
+            loan.setLoanStats(Loan.LoanStats.반납완료);
+        }
+    }
     public Loan findById(long id) {
         Optional<Loan> optionalLoan = loanRepository.findById(id);
         return optionalLoan.orElseThrow(()->new BusinessLogicException(ExceptionCode.LOAN_NOT_FOUND));
@@ -45,7 +53,7 @@ public class LoanService {
 
     public void validDuplicationLoan(Loan loan) {
         Member member = loan.getMember();
-        List<Loan> loanBooks = member.getLoanBooks();
+        List<Loan> loanBooks = member.getLoans();
         int count = 0;
         for(Loan loanedBook : loanBooks) {
             if(loanedBook.getLibraryInventory().getId().equals(loan.getLibraryInventory().getId())) {

--- a/src/main/java/server/bookmanagement/domain/member/controller/MemberController.java
+++ b/src/main/java/server/bookmanagement/domain/member/controller/MemberController.java
@@ -10,6 +10,8 @@ import server.bookmanagement.domain.member.mapper.MemberMapper;
 import server.bookmanagement.global.dto.SingleResponseDto;
 import server.bookmanagement.domain.member.service.MemberService;
 
+import javax.transaction.Transactional;
+
 @RestController
 @RequestMapping("/members")
 @RequiredArgsConstructor
@@ -25,6 +27,7 @@ public class MemberController {
         return new ResponseEntity<>(new SingleResponseDto<>(response), HttpStatus.CREATED);
     }
 
+    @Transactional
     @DeleteMapping("{member-id}")
     public ResponseEntity<?> deleteMember(@PathVariable("member-id") long memberId) {
         Member member = memberService.findById(memberId);

--- a/src/main/java/server/bookmanagement/domain/member/entity/Member.java
+++ b/src/main/java/server/bookmanagement/domain/member/entity/Member.java
@@ -25,7 +25,7 @@ public class Member extends BaseEntity {
     private Status status = Status.ACTIVE;
     @OneToMany(mappedBy = "member", cascade = CascadeType.REMOVE)
     @JsonManagedReference
-    private List<Loan> loanBooks = new ArrayList<>();
+    private List<Loan> loans = new ArrayList<>();
 
     //loan 에다가 회원의 연체패널티기간을 정해놓으면,
     //loan -> 책 한권빌릴때마다 history 식으로 남는거 ( 자꾸 많이 쌓이게됨 )

--- a/src/main/java/server/bookmanagement/domain/member/service/MemberService.java
+++ b/src/main/java/server/bookmanagement/domain/member/service/MemberService.java
@@ -46,7 +46,7 @@ public class MemberService {
         }
     }
     public boolean isOverQuantity(Member member) {
-        List<Loan> loanBooks = member.getLoanBooks();
+        List<Loan> loanBooks = member.getLoans();
         long loanNum = 0;
 
         for(Loan loan : loanBooks) {
@@ -64,15 +64,14 @@ public class MemberService {
     }
 
     public Member deleteMember(Member member) {
+        boolean hasActiveLoan = member.getLoans().stream()
+                .anyMatch(loan -> loan.getLoanStats().equals(Loan.LoanStats.대여중));
+
+        if (hasActiveLoan) {
+            throw new BusinessLogicException(ExceptionCode.UNABLE_MEMBER_ACCOUNT_WITHDRAWAL);
+        }
         member.setStatus(Member.Status.DELETED);
         return memberRepository.save(member);
-        // 논리적삭제
-        // 예시 : 탈퇴후 30일간은 사용자 정보 완전삭제 X
-        // 게시글도 나중에 혹시 완전 삭제 X
-
-        // S3에 이미지 업로드 할때 게시글 삭제되면 이미지 같이 삭제시킬라고 노력했는데
-        // 사실 운영하면 어디 클라우드 용량 이런거 신경 크게 안쓴데
-        // 그냥 최대한 함부러 물리적삭제 하는거 조심한데
     }
 
 

--- a/src/main/java/server/bookmanagement/global/error/exception/ExceptionCode.java
+++ b/src/main/java/server/bookmanagement/global/error/exception/ExceptionCode.java
@@ -16,7 +16,9 @@ public enum ExceptionCode {
     LOAN_QUANTITY_LIMIT(403,"동일한 책은 2권 이상 대여 불가능 합니다."),
     MEMBER_DELETED(404,"탈퇴한 사용자입니다."),
     BOOK_IS_DELETED(404,"삭제된 책 입니다."),
-    LIBRARY_IS_DELETED(404,"삭제된 도서관 입니다.")
+    LIBRARY_IS_DELETED(404,"삭제된 도서관 입니다."),
+    LIBRARY_INVENTORY_IS_DELETED(404,"도서관에서 삭제된 도서입니다."),
+    QUANTITY_UPDATE_IMPOSSIBLE(403,"변경하려는 수량보다 대여중인 책이 더 많습니다..")
     ;
 
     @Getter

--- a/src/main/java/server/bookmanagement/global/error/exception/ExceptionCode.java
+++ b/src/main/java/server/bookmanagement/global/error/exception/ExceptionCode.java
@@ -18,7 +18,8 @@ public enum ExceptionCode {
     BOOK_IS_DELETED(404,"삭제된 책 입니다."),
     LIBRARY_IS_DELETED(404,"삭제된 도서관 입니다."),
     LIBRARY_INVENTORY_IS_DELETED(404,"도서관에서 삭제된 도서입니다."),
-    QUANTITY_UPDATE_IMPOSSIBLE(403,"변경하려는 수량보다 대여중인 책이 더 많습니다..")
+    QUANTITY_UPDATE_IMPOSSIBLE(403,"변경하려는 수량보다 대여중인 책이 더 많습니다."),
+    LIBRARY_INVENTORY_ALREADY_EXISTS(403,"해당 도서관에 이미 등록된 책입니다.")
     ;
 
     @Getter

--- a/src/main/java/server/bookmanagement/global/error/exception/ExceptionCode.java
+++ b/src/main/java/server/bookmanagement/global/error/exception/ExceptionCode.java
@@ -19,7 +19,8 @@ public enum ExceptionCode {
     LIBRARY_IS_DELETED(404,"삭제된 도서관 입니다."),
     LIBRARY_INVENTORY_IS_DELETED(404,"도서관에서 삭제된 도서입니다."),
     QUANTITY_UPDATE_IMPOSSIBLE(403,"변경하려는 수량보다 대여중인 책이 더 많습니다."),
-    LIBRARY_INVENTORY_ALREADY_EXISTS(403,"해당 도서관에 이미 등록된 책입니다.")
+    LIBRARY_INVENTORY_ALREADY_EXISTS(403,"해당 도서관에 이미 등록된 책입니다."),
+    UNABLE_MEMBER_ACCOUNT_WITHDRAWAL(403,"대여중인 책이 있어서 탈퇴가 불가능 합니다.")
     ;
 
     @Getter


### PR DESCRIPTION
도서관 책 재고(LibraryInventory) 삭제,업데이트 로직추가 (총 재고 업데이트시 이미 대여중인 수량보다 많으면 오류처리)

Member,Book,library,libraryInventory,Loan 각 논리적 삭제처리시 연관관계파악 및 처리
Member 삭제 :
- Loan 대여중이면 회원탈퇴 불가능
- 나머지 관련 X
Book 삭제 :
- LibraryInventory 는 유지
- 나머지 관련 X
Library 삭제 :
- LibraryInventory 전부 논리적 삭제 처리
- Loan 은 유지 (반납/대여가 의미없어지는 data)
- 나머지 관련 X
LibraryInventory(도서관 등록된책재고) 삭제 :
- Loan 유지 ( 반납은 가능하게끔 )
- Book,Library 상세조회시 재고목록 안보이게 처리
- 나머지 관련 X
Loan 삭제 불가능 (History Log 역활)